### PR TITLE
Potential fix for code scanning alert no. 1: Potential use after free

### DIFF
--- a/src/C/core/jollyclick.c
+++ b/src/C/core/jollyclick.c
@@ -291,8 +291,8 @@ void *per_client_thread(void *arg) {
 
   close(targ->sockfd);
   PL_thread_destroy_engine();
-  free(targ);
   fprintf(stderr, "[DEBUG] [Thread Per-Client %ld] Exiting per_client_thread.\n", targ->thread_logical_id);
+  free(targ);
   return NULL;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/clickpaddle/jollyclick/security/code-scanning/1](https://github.com/clickpaddle/jollyclick/security/code-scanning/1)

To fix the issue, ensure that the `targ` pointer is not accessed after it has been freed. The best approach is to move the logging statement on line 295 to a position before the `free(targ)` call on line 294. This ensures that the pointer is accessed while it is still valid. No additional functionality needs to be added, and the existing behavior of the program remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
